### PR TITLE
Publish compiler plugin against full Scala version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ project/target/*
 .idea/*
 .idea_modules/*
 *.iml
+.vscode
+.idea
+.bloop
+.metals

--- a/acyclic/src/acyclic/plugin/PluginPhase.scala
+++ b/acyclic/src/acyclic/plugin/PluginPhase.scala
@@ -158,7 +158,8 @@ class PluginPhase(val global: Global,
 
           units.find(_.source.path == locs.head.pos.source.path)
                .get
-               .echo(locs.head.pos, "")
+
+          global.reporter.echo(locs.head.pos, "")
 
           val otherLines = locs.tail
                                .map(_.pos.line)

--- a/build.sc
+++ b/build.sc
@@ -1,9 +1,10 @@
 import mill._, scalalib._, publish._
 
-object acyclic extends Cross[AcyclicModule]("2.12.8", "2.13.0")
+object acyclic extends Cross[AcyclicModule]("2.12.8", "2.13.0", "2.13.2")
 class AcyclicModule(val crossScalaVersion: String) extends CrossScalaModule with PublishModule {
   def artifactName = "acyclic"
   def publishVersion = "0.2.0"
+  def crossFullScalaVersion = true
 
   def pomSettings = PomSettings(
     description = artifactName(),


### PR DESCRIPTION
Attempt to fix https://github.com/com-lihaoyi/acyclic/issues/36 by following [recommendation](https://github.com/typelevel/kind-projector/issues/15#issuecomment-497454212) 

> we do normally recommend that compiler plugins be published against the full Scala version.

Tested locally on simple hello world project using Scala 2.13.2 by publishing with

```
mill all __.publishLocal
```