### PR TITLE
Cross publish acyclic against full scala version

### DIFF
--- a/acyclic/src/acyclic/plugin/PluginPhase.scala
+++ b/acyclic/src/acyclic/plugin/PluginPhase.scala
@@ -156,9 +156,7 @@ class PluginPhase(val global: Global,
             case Value.File(_, _) =>
           }
 
-          units.find(_.source.path == locs.head.pos.source.path)
-               .get
-               .echo(locs.head.pos, "")
+          global.reporter.echo(locs.head.pos, "")
 
           val otherLines = locs.tail
                                .map(_.pos.line)

--- a/build.sc
+++ b/build.sc
@@ -2,8 +2,13 @@ import mill._, scalalib._, publish._
 import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.9:0.1.1`
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 
-object acyclic extends Cross[AcyclicModule]("2.11.12", "2.12.8", "2.13.0")
+object acyclic extends Cross[AcyclicModule](
+  "2.11.12",
+  "2.12.8", "2.12.9", "2.12.10", "2.12.11", "2.12.12", "2.12.13", "2.12.14", "2.12.15",
+  "2.13.0", "2.13.1", "2.13.2", "2.13.3", "2.13.4", "2.13.5", "2.13.6", "2.13.7"
+)
 class AcyclicModule(val crossScalaVersion: String) extends CrossScalaModule with PublishModule {
+  def crossFullScalaVersion = true
   def artifactName = "acyclic"
   def publishVersion = VcsVersion.vcsState().format()
 

--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,7 @@ How to Use
 To use, add the following to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.3.0" % "provided"
+libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.3.0" cross (CrossVersion.full) % "provided"
 
 autoCompilerPlugins := true
 

--- a/readme.md
+++ b/readme.md
@@ -185,7 +185,8 @@ addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.3.0")
 For Mill, use the following:
 
 ```scala
-def compileIvyDeps = Agg(ivy"com.lihaoyi::acyclic:0.3.0")
+def compileIvyDeps = Agg(ivy"com.lihaoyi:::acyclic:0.3.0")
+def scalacPluginIvyDeps = Agg(ivy"com.lihaoyi:::acyclic:0.3.0")
 ```
 
 If you are on Scala 2.10.x, you may need an additional compile-time dependency:

--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,12 @@ autoCompilerPlugins := true
 addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.3.0")
 ```
 
+For Mill, use the following:
+
+```scala
+def compileIvyDeps = Agg(ivy"com.lihaoyi::acyclic:0.3.0")
+```
+
 If you are on Scala 2.10.x, you may need an additional compile-time dependency:
 
 ```scala

--- a/readme.md
+++ b/readme.md
@@ -175,11 +175,11 @@ How to Use
 To use, add the following to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.7" % "provided"
+libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.3.0" % "provided"
 
 autoCompilerPlugins := true
 
-addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7")
+addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.3.0")
 ```
 
 If you are on Scala 2.10.x, you may need an additional compile-time dependency:
@@ -229,6 +229,8 @@ Acyclic has problems in a number of cases:
 
 ChangeLog
 =========
+
+**0.3.0**: Cross-build across all scala point versions
 
 **0.2.0**: Support for Scala 2.13.0 final
 


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/acyclic/issues/36.

Not sure about the update to the usage instructions... Anyone know how to depend on this in a build.sbt file? It's been a while since I last used SBT