### PR TITLE
Fix Java classpath retrieval in tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
       - name: Run tests
         run: ./mill __.publishArtifacts + __.test
 
@@ -35,6 +35,6 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
       - name: Publish to Maven Central
         run: ./mill -i mill.scalalib.PublishModule/

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -37,4 +37,17 @@ jobs:
           distribution: 'temurin'
           java-version: 11
       - name: Publish to Maven Central
-        run: ./mill -i mill.scalalib.PublishModule/
+        run: |
+          if [[ $(git tag --points-at HEAD) != '' ]]; then
+            echo $MILL_PGP_SECRET_BASE64 | base64 --decode > gpg_key
+            gpg --import --no-tty --batch --yes gpg_key
+            rm gpg_key
+            ./mill -i mill.scalalib.PublishModule/publishAll \
+              --sonatypeCreds $MILL_SONATYPE_USER:$MILL_SONATYPE_PASSWORD \
+              --gpgArgs --passphrase=$MILL_PGP_PASSPHRASE,--no-tty,--pinentry-mode,loopback,--batch,--yes,-a,-b \
+              --publishArtifacts __.publishArtifacts \
+              --readTimeout 600000 \
+              --awaitTimeout 600000 \
+              --release true \
+              --signed true
+          fi

--- a/acyclic/test/src-2/acyclic/TestUtils.scala
+++ b/acyclic/test/src-2/acyclic/TestUtils.scala
@@ -37,8 +37,6 @@ object TestUtils extends BaseTestUtils {
     val entries = getJavaClasspathEntries()
     settings.outputDirs.setSingleOutput(vd)
 
-    println(s"entries: ${entries.toIndexedSeq}")
-
     // annoyingly, the Scala library is not in our classpath, so we have to add it manually
     val sclpath = entries.map(
       _.replaceAll("scala-compiler.jar", "scala-library.jar")

--- a/acyclic/test/src-2/acyclic/TestUtils.scala
+++ b/acyclic/test/src-2/acyclic/TestUtils.scala
@@ -34,9 +34,10 @@ object TestUtils extends BaseTestUtils {
 
     val vd = new VirtualDirectory("(memory)", None)
     lazy val settings = new Settings
-    val loader = getClass.getClassLoader.asInstanceOf[URLClassLoader]
-    val entries = loader.getURLs map (_.getPath)
+    val entries = getJavaClasspathEntries()
     settings.outputDirs.setSingleOutput(vd)
+
+    println(s"entries: ${entries.toIndexedSeq}")
 
     // annoyingly, the Scala library is not in our classpath, so we have to add it manually
     val sclpath = entries.map(
@@ -56,7 +57,7 @@ object TestUtils extends BaseTestUtils {
     }
 
     var cycles: Option[Seq[Seq[(acyclic.plugin.Value, SortedSet[Int])]]] = None
-    val storeReporter = if (collectInfo) Some(new StoreReporter()) else None
+    val storeReporter = if (collectInfo) Some(new StoreReporter(settings)) else None
 
     lazy val compiler = new Global(settings, storeReporter.getOrElse(new ConsoleReporter(settings))) {
       override protected def loadRoughPluginsList(): List[Plugin] = {

--- a/acyclic/test/src-2/acyclic/TestUtils.scala
+++ b/acyclic/test/src-2/acyclic/TestUtils.scala
@@ -57,7 +57,7 @@ object TestUtils extends BaseTestUtils {
     }
 
     var cycles: Option[Seq[Seq[(acyclic.plugin.Value, SortedSet[Int])]]] = None
-    val storeReporter = if (collectInfo) Some(new StoreReporter(settings)) else None
+    val storeReporter = if (collectInfo) Some(new StoreReporter()) else None
 
     lazy val compiler = new Global(settings, storeReporter.getOrElse(new ConsoleReporter(settings))) {
       override protected def loadRoughPluginsList(): List[Plugin] = {

--- a/acyclic/test/src-3/acyclic/TestUtils.scala
+++ b/acyclic/test/src-3/acyclic/TestUtils.scala
@@ -33,8 +33,7 @@ object TestUtils extends BaseTestUtils {
     val src = "acyclic/test/resources/" + path
     val sources = (getFilePaths(src) ++ extraIncludes).map(f => PlainFile(Path(Paths.get(f))))
     val vd = new VirtualDirectory("(memory)", None)
-    val loader = getClass.getClassLoader.asInstanceOf[URLClassLoader]
-    val entries = loader.getURLs map (_.getPath)
+    val entries = getJavaClasspathEntries()
 
     val scalaSettings = new ScalaSettings {}
     val settingsState1 = scalaSettings.outputDir.updateIn(scalaSettings.defaultState, vd)

--- a/acyclic/test/src/acyclic/BaseTestUtils.scala
+++ b/acyclic/test/src/acyclic/BaseTestUtils.scala
@@ -35,19 +35,22 @@ abstract class BaseTestUtils {
       .split(java.io.File.pathSeparator)
       .toIndexedSeq
       .flatMap { f =>
-        val extra = for {
-          manifest <- Option.when(f.endsWith(".jar"))(new JarFile(f).getManifest()).toSeq
-          mainAttr <- Option(manifest.getMainAttributes()).toSeq
-          cp <-Option(mainAttr.getValue("Class-Path")).toSeq
-          entry <- cp.split(" ")
-          if entry.nonEmpty
-        } yield entry match {
-          case url if url.startsWith("file:///") =>
-            url.substring("file://".length)
-          case url if url.startsWith("file:/") =>
-            url.substring("file:".length)
-          case s => s
-        }
+        // If an (empty) classpath pathing jar is used, we extract the `Class-Path` manifest entry
+        // and those entries to the classpath
+        val extra =
+          for {
+            manifest <- Option.when(f.endsWith(".jar"))(new JarFile(f).getManifest()).toSeq
+            mainAttr <- Option(manifest.getMainAttributes()).toSeq
+            cp <- Option(mainAttr.getValue("Class-Path")).toSeq
+            entry <- cp.split(" ")
+            if entry.nonEmpty
+          } yield entry match {
+            case url if url.startsWith("file:///") =>
+              url.substring("file://".length)
+            case url if url.startsWith("file:/") =>
+              url.substring("file:".length)
+            case s => s
+          }
         Seq(f) ++ extra
       }
   }

--- a/acyclic/test/src/acyclic/BaseTestUtils.scala
+++ b/acyclic/test/src/acyclic/BaseTestUtils.scala
@@ -38,19 +38,21 @@ abstract class BaseTestUtils {
         // If an (empty) classpath pathing jar is used, we extract the `Class-Path` manifest entry
         // and those entries to the classpath
         val extra =
-          for {
-            manifest <- Option.when(f.endsWith(".jar"))(new JarFile(f).getManifest()).toSeq
-            mainAttr <- Option(manifest.getMainAttributes()).toSeq
-            cp <- Option(mainAttr.getValue("Class-Path")).toSeq
-            entry <- cp.split(" ")
-            if entry.nonEmpty
-          } yield entry match {
-            case url if url.startsWith("file:///") =>
-              url.substring("file://".length)
-            case url if url.startsWith("file:/") =>
-              url.substring("file:".length)
-            case s => s
-          }
+          if (!f.toLowerCase().endsWith(".jar")) Seq()
+          else
+            for {
+              manifest <- Option(new JarFile(f).getManifest()).toSeq
+              mainAttr <- Option(manifest.getMainAttributes()).toSeq
+              cp <- Option(mainAttr.getValue("Class-Path")).toSeq
+              entry <- cp.split(" ")
+              if entry.nonEmpty
+            } yield entry match {
+              case url if url.startsWith("file:///") =>
+                url.substring("file://".length)
+              case url if url.startsWith("file:/") =>
+                url.substring("file:".length)
+              case s => s
+            }
         Seq(f) ++ extra
       }
   }

--- a/build.sc
+++ b/build.sc
@@ -6,7 +6,7 @@ import de.tobiasroeser.mill.vcs.version.VcsVersion
 object Deps {
   val scala211 = Seq("2.11.12")
   val scala212 = 9.to(20).map("2.12." + _)
-  val scala213 = 1.to(16).map("2.13." + _)
+  val scala213 = 3.to(16).map("2.13." + _)
   val scala33 = 0.to(3).map("3.3." + _)
   val scala34 = 0.to(3).map("3.4." + _)
   val scala35 = 0.to(2).map("3.5." + _)

--- a/build.sc
+++ b/build.sc
@@ -49,6 +49,19 @@ trait AcyclicModule extends CrossScalaModule with PublishModule {
   override def compileIvyDeps =
     Agg(Deps.scalaCompiler(crossScalaVersion))
 
+  override def javacOptions = Seq(
+    "-source", "8", "-target", "8", "-encoding", "UTF-8"
+  )
+
+  override def scalacOptions =
+    if (crossScalaVersion.startsWith("2.")) Seq(
+      "-target:jvm-1.8"
+    )
+    else Seq(
+      "-java-output-version",
+      "8"
+    )
+
   object test extends ScalaTests with TestModule.Utest {
     override def sources = T.sources(super.sources() :+ PathRef(millSourcePath / "resources"))
     override def ivyDeps = Agg(


### PR DESCRIPTION
The classpath retieval used some internal knowledge and cast the classloader to `URLClassLoader`. This no longer works in newer Java version (Java 11+), hence another method to retrieve the currently used classpath was implemented based on the `java.class.path` system property.

Also restore the CI publish setup for Mill 0.11.