### PR TITLE
Base test resource recovery on sys env variables

### DIFF
--- a/acyclic/test/src-2/acyclic/TestUtils.scala
+++ b/acyclic/test/src-2/acyclic/TestUtils.scala
@@ -24,12 +24,13 @@ object TestUtils extends BaseTestUtils {
    */
   def make(
       path: String,
-      extraIncludes: Seq[String] = Seq("acyclic/src/acyclic/package.scala"),
+      extraIncludes: Seq[String] =
+        Seq(workspaceRoot + "/acyclic/src/acyclic/package.scala"),
       force: Boolean = false,
       warn: Boolean = false,
       collectInfo: Boolean = true
   ): Seq[(String, String)] = {
-    val src = "acyclic/test/resources/" + path
+    val src = testResources + "/" + path
     val sources = getFilePaths(src) ++ extraIncludes
 
     val vd = new VirtualDirectory("(memory)", None)
@@ -95,7 +96,7 @@ object TestUtils extends BaseTestUtils {
       .toSet
 
     def expand(v: Value) = v match {
-      case Value.File(filePath, pkg) => Value.File("acyclic/test/resources/" + path + "/" + filePath, Nil)
+      case Value.File(filePath, pkg) => Value.File(testResources + "/" + path + "/" + filePath, Nil)
       case v => v
     }
 

--- a/acyclic/test/src-3/acyclic/TestUtils.scala
+++ b/acyclic/test/src-3/acyclic/TestUtils.scala
@@ -25,12 +25,13 @@ object TestUtils extends BaseTestUtils {
    */
   def make(
       path: String,
-      extraIncludes: Seq[String] = Seq("acyclic/src/acyclic/package.scala"),
+      extraIncludes: Seq[String] =
+        Seq(workspaceRoot + "/acyclic/src/acyclic/package.scala"),
       force: Boolean = false,
       warn: Boolean = false,
       collectInfo: Boolean = true
   ): Seq[(String, String)] = {
-    val src = "acyclic/test/resources/" + path
+    val src = testResources + "/" + path
     val sources = (getFilePaths(src) ++ extraIncludes).map(f => PlainFile(Path(Paths.get(f))))
     val vd = new VirtualDirectory("(memory)", None)
     val entries = getJavaClasspathEntries()
@@ -107,7 +108,7 @@ object TestUtils extends BaseTestUtils {
       .toSet
 
     def expand(v: Value) = v match {
-      case Value.File(filePath, pkg) => Value.File("acyclic/test/resources/" + path + "/" + filePath, Nil)
+      case Value.File(filePath, pkg) => Value.File(testResources + "/" + path + "/" + filePath, Nil)
       case v => v
     }
 

--- a/acyclic/test/src/acyclic/BaseTestUtils.scala
+++ b/acyclic/test/src/acyclic/BaseTestUtils.scala
@@ -8,6 +8,8 @@ import scala.collection.SortedSet
 abstract class BaseTestUtils {
   val srcDirName: String
 
+  val workspaceRoot = sys.env("MILL_WORKSPACE_ROOT")
+  val testResources = sys.env("TEST_ACYCLIC_TEST_RESOURCES")
   /**
    * Attempts to compile a resource folder as a compilation run, in order
    * to test whether it succeeds or fails correctly.

--- a/build.sc
+++ b/build.sc
@@ -50,7 +50,12 @@ trait AcyclicModule extends CrossScalaModule with PublishModule {
     Agg(Deps.scalaCompiler(crossScalaVersion))
 
   override def javacOptions = Seq(
-    "-source", "8", "-target", "8", "-encoding", "UTF-8"
+    "-source",
+    "8",
+    "-target",
+    "8",
+    "-encoding",
+    "UTF-8"
   )
 
   override def scalacOptions =
@@ -69,5 +74,9 @@ trait AcyclicModule extends CrossScalaModule with PublishModule {
       Deps.scalaCompiler(crossScalaVersion)
     )
     override def scalacPluginIvyDeps = Agg.empty[Dep]
+    override def forkEnv = super.forkEnv() ++ Map(
+      "MILL_WORKSPACE_ROOT" -> T.workspace.toString,
+      "TEST_ACYCLIC_TEST_RESOURCES" -> (millSourcePath / "resources").toString
+    )
   }
 }


### PR DESCRIPTION
Instead of assuming some paths, we refer to env variables as resources roots:

* `MILL_WORKSPACE_ROOT`
* `TEST_ACYCLIC_TEST_RESOURCES`